### PR TITLE
fix(ci): fix incorrect reference to npm credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
 
       environment {
         GITHUB_TOKEN = credentials('github-api-token')
-        NPM_TOKEN = credentials('github-api-token')
+        NPM_TOKEN = credentials('npm-publish-token')
         NPM_CONFIG_CACHE = '.npm'
         NPM_CONFIG_USERCONFIG = '.npm/rc'
         SPAWN_WRAP_SHIM_ROOT = '.npm'


### PR DESCRIPTION
Correct the token used to populated NPM_TOKEN.
The npm token was pulling the github token, which is used for publishing
to github packages rather than the public npm registry

Semver: patch