### PR TITLE
Update install instructions and package name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 library 'magic-butler-catalogue'
 
-def PROJECT_NAME = "release-config-logdna"
+def PROJECT_NAME = "semantic-release-config-logdna"
 def CURRENT_BRANCH = [env.CHANGE_BRANCH, env.BRANCH_NAME]?.find{branch -> branch != null}
 def TRIGGER_PATTERN = ".*@logdnabot.*"
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ The shareable configuration can be configured in the [**semantic-release** confi
 ### Installation
 
 ```shell
-$ npm install semantic-release-config-logdna
+$ npm install --save-dev semantic-release semantic-release-config-logdna
 ```
 
 ```json
+// package.json
 {
   "release": {
     "branches": ["main"],

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -7,7 +7,7 @@ function sortByType(a, b) {
   return a.type < b.type ? -1 : 1
 }
 
-test('release-config-logdna', async (t) => {
+test('semantic-release-config-logdna', async (t) => {
   const plugins = config.plugins.map((plugin) => {
     return plugin[0]
   })


### PR DESCRIPTION
Cleans up a few items post-release

- Adds missing required packages to the install command
- This fixes a couple of locations still referencing the old package name

Semver: patch