### PR TITLE
feat(github): attach all assets in ./dist to release

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ npm install --save-dev semantic-release semantic-release-config-logdna
   * Includes links to commit sha
   * Organizes changes by type
 * Commits standardized `release` commit back upstream
+* Attaches any build artifacts placed in `./dist` to the release
 
 
 ### Commit Types

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = {
         + 'Version <%= nextRelease.version %> [skip ci]'
     }]
   , ['@semantic-release/github', {
-      assets: 'dist/*.tgz'
+      assets: 'dist/*'
     }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     }
   },
   "tap": {
-    "esm": false,
     "ts": false,
     "jsx": false,
     "browser": false,
@@ -98,10 +97,10 @@
   },
   "devDependencies": {
     "eslint": "^7.19.0",
-    "eslint-config-logdna": "^4.0.2",
+    "eslint-config-logdna": "^5.0.0",
     "handlebars": "^4.7.6",
     "semantic-release": "^17.3.8",
-    "tap": "^14.11.0",
+    "tap": "^15.0.6",
     "tap-parser": "^10.1.0",
     "tap-xunit": "^2.4.1"
   },

--- a/test/unit/commit/typeof.js
+++ b/test/unit/commit/typeof.js
@@ -4,85 +4,85 @@ const {test, threw} = require('tap')
 const {typeOf} = require('../../../lib/commit.js')
 
 test('commit#typeOf', async (t) => {
-  t.strictEqual(
+  t.equal(
     typeOf('build')
   , 'Build System'
   , 'build -> Build System'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('chore')
   , 'Chores'
   , 'chore -> Chores'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('ci')
   , 'Continuous Integration'
   , 'ci -> Continuous Integration'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('doc')
   , 'Documentation'
   , 'doc -> Documentation'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('feat')
   , 'Features'
   , 'feat -> Features'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('fix')
   , 'Bug Fixes'
   , 'fix -> Bug Fixes'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('lint')
   , 'Lint'
   , 'lint -> Lint'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('perf')
   , 'Performance Improvements'
   , 'perf -> Performance Improvements'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('refactor')
   , 'Code Refactoring'
   , 'refactor -> Code Refactoring'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('revert')
   , 'Reverts'
   , 'revert -> Reverts'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('style')
   , 'Style'
   , 'style -> Style'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('test')
   , 'Tests'
   , 'test -> Tests'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('unknown')
   , 'Miscellaneous'
   , 'unknown -> Miscellaneous'
   )
 
-  t.strictEqual(
+  t.equal(
     typeOf('foobar')
   , 'Miscellaneous'
   , 'foobar -> Miscellaneous'

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -13,7 +13,7 @@ test('semantic-release-config-logdna', async (t) => {
     return plugin[0]
   })
 
-  t.strictEqual(config.npmPublish, true, 'npmPublish = true by default')
+  t.equal(config.npmPublish, true, 'npmPublish = true by default')
   t.match(config.parserOpts, {
     noteKeywords: ['BREAKING CHANGES', 'BREAKING CHANGE', 'BREAKING']
   , headerPattern: /^(\w*)(?:\((.*)\))?!?: (.*)$/
@@ -27,7 +27,7 @@ test('semantic-release-config-logdna', async (t) => {
     ]
   }, 'default commit parser options')
 
-  t.deepEqual(config.releaseRules.sort(sortByType), [
+  t.same(config.releaseRules.sort(sortByType), [
     {breaking: true, release: 'major'}
   , {type: 'build', release: 'patch'}
   , {type: 'ci', release: 'patch'}
@@ -42,7 +42,7 @@ test('semantic-release-config-logdna', async (t) => {
   , {type: 'test', release: 'patch'}
   ].sort(sortByType), 'expected default release rules')
 
-  t.deepEqual(plugins, [
+  t.same(plugins, [
     '@semantic-release/commit-analyzer'
   , '@semantic-release/release-notes-generator'
   , '@semantic-release/changelog'

--- a/test/unit/constants.js
+++ b/test/unit/constants.js
@@ -4,7 +4,7 @@ const {test, threw} = require('tap')
 const constants = require('../../lib/constants.js')
 
 test('constants', async (t) => {
-  t.strictEqual(Object.keys(constants).length, 1, 'expected number of constants')
+  t.equal(Object.keys(constants).length, 1, 'expected number of constants')
 
   t.match(constants, {
     BREAKING_HEADER_REGEX: RegExp
@@ -15,16 +15,16 @@ test('constants', async (t) => {
     t.test('breaking change w/o scope', async (t) => {
       const match = BREAKING_HEADER_REGEX.exec('test!: this is breaking')
       const [_, type, scope, subject] = match
-      t.strictEqual(type, 'test', 'commit type')
-      t.strictEqual(scope, undefined, 'commit scope')
-      t.strictEqual(subject, 'this is breaking', 'commit subject')
+      t.equal(type, 'test', 'commit type')
+      t.equal(scope, undefined, 'commit scope')
+      t.equal(subject, 'this is breaking', 'commit subject')
     })
     t.test('breaking change w/ scope', async (t) => {
       const match = BREAKING_HEADER_REGEX.exec('doc(readme)!: this is breaking')
       const [_, type, scope, subject] = match
-      t.strictEqual(type, 'doc', 'commit type')
-      t.strictEqual(scope, 'readme', 'commit scope')
-      t.strictEqual(subject, 'this is breaking', 'commit subject')
+      t.equal(type, 'doc', 'commit type')
+      t.equal(scope, 'readme', 'commit scope')
+      t.equal(subject, 'this is breaking', 'commit subject')
     })
     t.test('non-breaking change', async (t) => {
       const match = BREAKING_HEADER_REGEX.exec('doc(readme): this is breaking')


### PR DESCRIPTION
**feat(github): attach all assets in ./dist to release**

Previously this was limited to files with the `tgz` extension,
but it would be useful to, as a convention, publish _anything_
generated in that directory as a release asset.

Closes #9

---

**chore(deps): update eslint-config-logdna@5.0.0** 

Pulls in the latest eslint config, along with tap@15
and applies fixes per the latest lint rules